### PR TITLE
Improve incrementToken implementation in MorphologyFilter

### DIFF
--- a/english/pom.xml
+++ b/english/pom.xml
@@ -19,11 +19,5 @@
             <version>1.2-SNAPSHOT</version>
         </dependency>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.2</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/morph/src/main/java/org/apache/lucene/morphology/analyzer/MorphologyFilter.java
+++ b/morph/src/main/java/org/apache/lucene/morphology/analyzer/MorphologyFilter.java
@@ -19,18 +19,22 @@ package org.apache.lucene.morphology.analyzer;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.KeywordAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.morphology.LuceneMorphology;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 
 
 public class MorphologyFilter extends TokenFilter {
     private LuceneMorphology luceneMorph;
     private Iterator<String> iterator;
     private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+    private final KeywordAttribute keywordAttr = addAttribute(KeywordAttribute.class);
     private final PositionIncrementAttribute position = addAttribute(PositionIncrementAttribute.class);
+    private State state = null;
 
     public MorphologyFilter(TokenStream tokenStream, LuceneMorphology luceneMorph) {
         super(tokenStream);
@@ -39,27 +43,39 @@ public class MorphologyFilter extends TokenFilter {
 
 
     final public boolean incrementToken() throws IOException {
-        boolean oldToken = true;
-        while (iterator == null || !iterator.hasNext()) {
+        if (iterator != null) {
+            if (iterator.hasNext()) {
+                restoreState(state);
+                position.setPositionIncrement(0);
+                termAtt.setEmpty().append(iterator.next());
+                return true;
+            } else {
+                state = null;
+                iterator = null;
+            }
+        }
+        while (true) {
             boolean b = input.incrementToken();
             if (!b) {
                 return false;
             }
-            String s = new String(termAtt.buffer(), 0, termAtt.length());
-            if (luceneMorph.checkString(s)) {
-                oldToken = false;
-                iterator = luceneMorph.getNormalForms(s).iterator();
-            } else {
-                return true;
+            if (!keywordAttr.isKeyword() && termAtt.length() > 0) {
+                String s = new String(termAtt.buffer(), 0, termAtt.length());
+                if (luceneMorph.checkString(s)) {
+                    List<String> forms = luceneMorph.getNormalForms(s);
+                    if (forms.isEmpty()) {
+                        continue;
+                    } else if (forms.size() == 1) {
+                        termAtt.setEmpty().append(forms.get(0));
+                    } else {
+                        state = captureState();
+                        iterator = forms.iterator();
+                        termAtt.setEmpty().append(iterator.next());
+                    }
+                }
             }
+            return true;
         }
-        String s = iterator.next();
-        termAtt.setEmpty();
-        termAtt.append(s);
-        if (oldToken) {
-            position.setPositionIncrement(0);
-        }
-        return true;
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,10 @@
         <tag>HEAD</tag>
     </scm>
 
+    <properties>
+        <lucene.version>5.1.0</lucene.version>
+    </properties>
+
     <distributionManagement>
         <repository>
             <id>bintray</id>
@@ -24,9 +28,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-test-framework</artifactId>
+            <version>${lucene.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -38,12 +42,12 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>5.1.0</version>
+            <version>${lucene.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analyzers-common</artifactId>
-            <version>5.1.0</version>
+            <version>${lucene.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The current implementation doesn't preserve the attributes of the repeated tokens and stems tokens marked as keywords.