### PR TITLE
Upgrade to Lucene 6.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 # Russian Morphology for lucene
 
-Russian and English morphology for java and lucene 5.1 framework based on open source dictionary from site [АОТ](http://aot.ru). It use dictionary base morphology with some heuristics for unknown words. It support homonym for example for Russian word "вина" it gives two variants "вино" and "вина". 
+Russian and English morphology for java and lucene 6.1 framework based on open source dictionary from site [АОТ](http://aot.ru). It use dictionary base morphology with some heuristics for unknown words. It support homonym for example for Russian word "вина" it gives two variants "вино" and "вина".
 
 
 ### How to use
 
 First download 
-[morph-1.0.jar](https://bintray.com/artifact/download/akuznetsov/russianmorphology/org/apache/lucene/morphology/morph/1.1/morph-1.1.jar)  
-and add it to your class path. When download [Russian](https://bintray.com/artifact/download/akuznetsov/russianmorphology/org/apache/lucene/morphology/russian/1.1/russian-1.1.jar) or 
-[English](https://bintray.com/artifact/download/akuznetsov/russianmorphology/org/apache/lucene/morphology/english/1.1/english-1.1.jar) package. 
+[morph-1.2.jar](https://bintray.com/artifact/download/akuznetsov/russianmorphology/org/apache/lucene/morphology/morph/1.2/morph-1.2.jar)  
+and add it to your class path. When download [Russian](https://bintray.com/artifact/download/akuznetsov/russianmorphology/org/apache/lucene/morphology/russian/1.2/russian-1.2.jar) or 
+[English](https://bintray.com/artifact/download/akuznetsov/russianmorphology/org/apache/lucene/morphology/english/1.2/english-1.2.jar) package. 
 
 If you use maven you can add dependency 
 
         <dependency>
             <groupId>org.apache.lucene.morphology</groupId>
             <artifactId>russian</artifactId>
-            <version>1.1</version>
+            <version>1.2</version>
         </dependency>
 
 
         <dependency>
             <groupId>org.apache.lucene.morphology</groupId>
             <artifactId>english</artifactId>
-            <version>1.1</version>
+            <version>1.2</version>
         </dependency>
 
 Don't forget add link to repository

--- a/morph/src/main/java/org/apache/lucene/morphology/analyzer/MorphologyAnalyzer.java
+++ b/morph/src/main/java/org/apache/lucene/morphology/analyzer/MorphologyAnalyzer.java
@@ -76,7 +76,7 @@ public class MorphologyAnalyzer extends Analyzer {
 
         return new TokenStreamComponents(src, filter) {
             @Override
-            protected void setReader(final Reader reader) throws IOException {
+            protected void setReader(final Reader reader) {
                 super.setReader(reader);
             }
         };

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     </scm>
 
     <properties>
-        <lucene.version>5.1.0</lucene.version>
+        <lucene.version>6.1.0</lucene.version>
     </properties>
 
     <distributionManagement>
@@ -97,14 +97,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>                <!--                 usage: http://code.google.com/p/maven-license-plugin/wiki/HowTo                -->
                 <artifactId>maven-license-plugin</artifactId>
-                <groupId>com.mathieucarbou.mojo</groupId>
+                <groupId>com.google.code.maven-license-plugin</groupId>
+                <version>1.4.0</version>
                 <configuration>
                     <basedir>${project.parent.basedir}</basedir>
                     <header>etc/header.txt</header>
@@ -135,6 +137,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-source-plugin</artifactId>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -146,6 +149,7 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.10.4</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
I would like to release a version of Elasticsearch russianmorphology plugin for one of the 5.0.0 alphas and elasticsearch has moved to Lucene 6.1. It would be awesome if you could release a new version of russianmorphology library for Lucene 6.1. Thanks!