### PR TITLE
The real fix of InvalidTokenOffsetsException

### DIFF
--- a/morph/src/main/java/org/apache/lucene/morphology/analyzer/MorphologyFilter.java
+++ b/morph/src/main/java/org/apache/lucene/morphology/analyzer/MorphologyFilter.java
@@ -82,5 +82,6 @@ public class MorphologyFilter extends TokenFilter {
     public void reset() throws IOException {
         super.reset();
         state = null;
+        iterator = null;
     }
 }


### PR DESCRIPTION
In the previous push request i forgot to clear  variable "iterator"  that also contaned state of filter.
Now highlights feature works fine at our solr prod.