### PR TITLE
Lucene upgrade to 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Russian Morphology for Apache Lucene
 
-Russian and English morphology for Java and [Apache Lucene](http://lucene.apache.org) 6.6 framework based on open source dictionary from site [АОТ](http://aot.ru). It use dictionary base morphology with some heuristics for unknown words. It support homonym for example for Russian word "вина" it gives two variants "вино" and "вина".
+Russian and English morphology for Java and [Apache Lucene](http://lucene.apache.org) 7.2 framework based on open source dictionary from site [АОТ](http://aot.ru). It use dictionary base morphology with some heuristics for unknown words. It support homonym for example for Russian word "вина" it gives two variants "вино" and "вина".
 
 
 ### How to use
 
-Build project, by running `mvn clean package`, this will provide you the latest versions of the artifacts - 1.3-SNAPSHOT, add it to your classpath. You could select which version to use - Russian or English.
+Build project, by running `mvn clean package`, this will provide you the latest versions of the artifacts - 1.4, add it to your classpath. You could select which version to use - Russian or English.
 
 Now you can create a Lucene Analyzer:
 
@@ -39,7 +39,7 @@ You can use the LuceneMorphology as morphology filter in a Solr _schema.xml_ usi
 </fieldType>
 ```
 
-Just add _morphology-1.3.jar_ in your Solr lib-directories
+Just add _morphology-1.4.jar_ in your Solr lib-directories
 
 ### Restrictions
   

--- a/dictionary-reader/pom.xml
+++ b/dictionary-reader/pom.xml
@@ -3,27 +3,27 @@
     <parent>
         <artifactId>morphology</artifactId>
         <groupId>org.apache.lucene.morphology</groupId>
-        <version>1.3-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.lucene.morphology</groupId>
     <artifactId>dictionary-reader</artifactId>
     <name>dictionary-reader</name>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.4</version>
     <url>http://maven.apache.org</url>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.lucene.morphology</groupId>
             <artifactId>russian</artifactId>
-            <version>1.3-SNAPSHOT</version>
+            <version>1.4</version>
         </dependency>
 
 
         <dependency>
             <groupId>org.apache.lucene.morphology</groupId>
             <artifactId>english</artifactId>
-            <version>1.3-SNAPSHOT</version>
+            <version>1.4</version>
         </dependency>
     </dependencies>
 

--- a/english/pom.xml
+++ b/english/pom.xml
@@ -3,20 +3,20 @@
     <parent>
         <artifactId>morphology</artifactId>
         <groupId>org.apache.lucene.morphology</groupId>
-        <version>1.3-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.lucene.morphology</groupId>
     <artifactId>english</artifactId>
     <name>english</name>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.4</version>
     <url>http://maven.apache.org</url>
     <dependencies>
 
         <dependency>
             <groupId>org.apache.lucene.morphology</groupId>
             <artifactId>morph</artifactId>
-            <version>1.3-SNAPSHOT</version>
+            <version>1.4</version>
         </dependency>
 
     </dependencies>

--- a/morph/pom.xml
+++ b/morph/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>morphology</artifactId>
         <groupId>org.apache.lucene.morphology</groupId>
-        <version>1.3-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.lucene.morphology</groupId>
     <artifactId>morph</artifactId>
     <name>morph</name>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.4</version>
     <url>http://maven.apache.org</url>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.apache.lucene.morphology</groupId>
     <artifactId>morphology</artifactId>
     <packaging>pom</packaging>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.4</version>
     <name>morphology</name>
     <url>http://maven.apache.org</url>
 
@@ -16,8 +16,8 @@
     </scm>
 
     <properties>
-        <lucene.version>6.6.0</lucene.version>
-        <morphology.version>1.3-SNAPSHOT</morphology.version>
+        <lucene.version>7.2.1</lucene.version>
+        <morphology.version>1.4</morphology.version>
         <junit.version>4.12</junit.version>
     </properties>
 

--- a/russian/pom.xml
+++ b/russian/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>morphology</artifactId>
         <groupId>org.apache.lucene.morphology</groupId>
-        <version>1.3-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.lucene.morphology</groupId>
     <artifactId>russian</artifactId>
     <name>russian</name>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.4</version>
     <url>http://maven.apache.org</url>
     <dependencies>
 
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.apache.lucene.morphology</groupId>
             <artifactId>morph</artifactId>
-            <version>1.3-SNAPSHOT</version>
+            <version>1.4</version>
         </dependency>
 
         <dependency>

--- a/solr-morphology-analysis/pom.xml
+++ b/solr-morphology-analysis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>morphology</artifactId>
         <groupId>org.apache.lucene.morphology</groupId>
-        <version>1.3-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Upgrade to the new version of Lucene is pretty painless as I can see, so it can be done only by version change in pom.xml.